### PR TITLE
Make Polux bushes check correct map for artificial building

### DIFF
--- a/1.4/Source/VanillaRacesExpanded-Phytokin/VanillaRacesExpanded-Phytokin/Comps/CompVariablePollutionPump.cs
+++ b/1.4/Source/VanillaRacesExpanded-Phytokin/VanillaRacesExpanded-Phytokin/Comps/CompVariablePollutionPump.cs
@@ -160,7 +160,7 @@ namespace VanillaRacesExpandedPhytokin
             base.CompTick();
             if (Props.disabledByArtificialBuildings && Find.TickManager.TicksGame % CheckInterval == 0)
             {
-                disabledByArtificialBuildings = Find.CurrentMap.listerArtificialBuildingsForMeditation.GetForCell(parent.Position, Props.radius + StaticCollectionsClass.polux_gene_colonists_inMap * 2).Count > 0;
+                disabledByArtificialBuildings = parent.Map.listerArtificialBuildingsForMeditation.GetForCell(parent.Position, Props.radius + StaticCollectionsClass.polux_gene_colonists_inMap * 2).Count > 0;
             }
             if (parent.IsHashIntervalTick(CheckInterval) && Active)
             {


### PR DESCRIPTION
Currently, they check the current map. This will work as long as the player is on a single map - in case of multiple settlements, or doing stuff off-map (attacking hostiles, quests, etc.) - this could cause the Polux bushes to to stop removing pollution when there's no artificial buildings, or start doing so even though there are some.