### PR TITLE
Cache solid Texture2D for the GeneGizmo_Resource bar patch

### DIFF
--- a/1.4/Source/VanillaRacesExpanded-Phytokin/VanillaRacesExpanded-Phytokin/GraphicsCache/GraphicsCache.cs
+++ b/1.4/Source/VanillaRacesExpanded-Phytokin/VanillaRacesExpanded-Phytokin/GraphicsCache/GraphicsCache.cs
@@ -9,6 +9,9 @@ namespace VanillaRacesExpandedPhytokin
     {
 
         public static readonly Graphic graphicMaturePlant = (Graphic_Single)GraphicDatabase.Get<Graphic_Single>("Things/Plant/SaplingChild", ShaderDatabase.CutoutComplex, Vector2.one, Color.white);
-      
+
+        public static readonly Texture2D poluxAffinityBarTex = SolidColorMaterials.NewSolidColorTexture(new ColorInt(128, 108, 131).ToColor);
+        public static readonly Texture2D poluxAffinityBarHighlightTex = SolidColorMaterials.NewSolidColorTexture(new ColorInt(150, 127, 153).ToColor);
+
     }
 }

--- a/1.4/Source/VanillaRacesExpanded-Phytokin/VanillaRacesExpanded-Phytokin/Harmony/GeneGizmo_Resource_GizmoOnGUI.cs
+++ b/1.4/Source/VanillaRacesExpanded-Phytokin/VanillaRacesExpanded-Phytokin/Harmony/GeneGizmo_Resource_GizmoOnGUI.cs
@@ -27,8 +27,8 @@ namespace VanillaRacesExpandedPhytokin
 
             if (___gene.def == InternalDefOf.VRE_PoluxAffinity)
             {
-                ___barTex = SolidColorMaterials.NewSolidColorTexture(new ColorInt(128, 108, 131).ToColor);
-                ___barHighlightTex = SolidColorMaterials.NewSolidColorTexture(new ColorInt(150, 127, 153).ToColor);
+                ___barTex = GraphicsCache.poluxAffinityBarTex;
+                ___barHighlightTex = GraphicsCache.poluxAffinityBarHighlightTex;
                 return;
             }
             


### PR DESCRIPTION
Fixes the issue where the textures would get endlessly created and fill up RAM, similarly to the issue with VRE-Sanguophage mod.